### PR TITLE
Fix: Rotate arrow icon to right when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/menu-item-button.tsx
+++ b/features/layout/sidebar-navigation/menu-item-button.tsx
@@ -22,7 +22,14 @@ export function MenuItemButton({
     <li className={classNames(styles.listItem, className)}>
       <Button className={styles.anchor} onClick={onClick}>
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img className={styles.icon} src={iconSrc} alt={`${text} icon`} />{" "}
+        <img
+          className={classNames(
+            styles.icon,
+            text === "Collapse" && isCollapsed && styles.rotate,
+          )}
+          src={iconSrc}
+          alt={`${text} icon`}
+        />{" "}
         {!isCollapsed && text}{" "}
       </Button>
     </li>

--- a/features/layout/sidebar-navigation/menu-item-link.module.scss
+++ b/features/layout/sidebar-navigation/menu-item-link.module.scss
@@ -30,3 +30,7 @@
   width: space.$s6;
   margin-right: space.$s3;
 }
+
+.icon.rotate {
+  transform: rotate(180deg);
+}


### PR DESCRIPTION
When the sidebar navigation is collapsed the arrow of the “Collapse” button points to the right.